### PR TITLE
cmake: exclude Linux-only "Timer" to fix build on macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,13 @@ AUX_SOURCE_DIRECTORY( ./src/ILDImpl library_sources )
 AUX_SOURCE_DIRECTORY( ./src/Tools library_sources )
 
 
+IF(APPLE)
+  # builds only on Linux
+  LIST(FILTER library_sources EXCLUDE REGEX "./src/Tools/Timer.cc")
+ENDIf()
+
+
+
 
 ADD_SHARED_LIBRARY( ${PROJECT_NAME} ${library_sources} )
 INSTALL_SHARED_LIBRARY( ${PROJECT_NAME} DESTINATION lib )


### PR DESCRIPTION

BEGINRELEASENOTES
- cmake: exclude Linux-only "Timer" to fix build on macos

ENDRELEASENOTES