### PR TITLE
Exclude Timer.cc from being built on arm64 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,23 +97,14 @@ AUX_SOURCE_DIRECTORY( ./src/ILDImpl library_sources )
 AUX_SOURCE_DIRECTORY( ./src/Tools library_sources )
 
 
-IF(APPLE)
-    # builds only on Linux
-    LIST(FILTER library_sources EXCLUDE REGEX "./src/Tools/Timer.cc")
-ENDIF()
-
 IF(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
     # exclude Timer.cc on arm64 systems
     LIST(FILTER library_sources EXCLUDE REGEX "./src/Tools/Timer.cc")
 ENDIF()
 
 
-
-
 ADD_SHARED_LIBRARY( ${PROJECT_NAME} ${library_sources} )
 INSTALL_SHARED_LIBRARY( ${PROJECT_NAME} DESTINATION lib )
-
-
 
 
 ### TESTING #################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ AUX_SOURCE_DIRECTORY( ./src/Tools library_sources )
 
 
 IF(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
-    # exclude Timer.cc on arm64 systems
+    # exclude Timer.cc on arm64 systems, since it has some x86 assembly statements
     LIST(FILTER library_sources EXCLUDE REGEX "./src/Tools/Timer.cc")
 ENDIF()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,9 +98,14 @@ AUX_SOURCE_DIRECTORY( ./src/Tools library_sources )
 
 
 IF(APPLE)
-  # builds only on Linux
-  LIST(FILTER library_sources EXCLUDE REGEX "./src/Tools/Timer.cc")
-ENDIf()
+    # builds only on Linux
+    LIST(FILTER library_sources EXCLUDE REGEX "./src/Tools/Timer.cc")
+ENDIF()
+
+IF(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
+    # exclude Timer.cc on arm64 systems
+    LIST(FILTER library_sources EXCLUDE REGEX "./src/Tools/Timer.cc")
+ENDIF()
 
 
 


### PR DESCRIPTION
This PR does what the title says.
This is a fix, inspired by https://github.com/iLCSoft/KiTrackMarlin/pull/7 to get the package to compile in the arm64-based releases.


BEGINRELEASENOTES
- Exclude Timer.cc from being built on arm64 

ENDRELEASENOTES